### PR TITLE
Remove unused helloWorld command from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,6 @@
 		"watch": "tsc -watch -p ./"
 	},
 	"contributes": {
-		"commands": [
-			{
-				"command": "macos-key-mapper.helloWorld",
-				"title": "Hello World"
-			}
-		],
 		"configuration": {
 			"title": "MacOS Key Mapper",
 			"type": "object",


### PR DESCRIPTION
## Summary
Removed the unused "Hello World" command contribution from the VS Code extension configuration.

## Changes
- Removed the `commands` section from `contributes` in package.json that defined the `macos-key-mapper.helloWorld` command
- This command was not being used and cluttered the extension's manifest

## Details
The "Hello World" command was a placeholder/example command that is no longer needed for the MacOS Key Mapper extension. Removing it cleans up the extension configuration and reduces unnecessary command registrations.

https://claude.ai/code/session_01SLYyVc4vYyooWRXrKmfCtd