### PR TITLE
feat: add Google Antigravity support

### DIFF
--- a/default_ahk/antigravity.ahk
+++ b/default_ahk/antigravity.ahk
@@ -1,0 +1,50 @@
+#HotIf WinActive('ahk_exe Antigravity.exe')
+
+#SingleInstance Force
+
+#c::^c
+#v::^v
+#x::^x
+#z::^z
+
+#/::^/
+
+#+p::^+p
+
+; File: Save
+#s::^s
+
+; close window
+#w::^w
+
+; actions.find
+#f::^f
+
+; workbench.action.quickOpen
+#p::^p
+
+; workbench.action.togglePanel
+#j::^j
+
+#Enter::^Enter
+
+#k::^k
+
+; editor.action.addSelectionToNextFindMatch
+#d::^d
+
+#a::^a
+#!s::Send '^{k}{s}'
+
+#.::^.
+
+#i::^i
+
+; Toggle primary sidebar visibility
+#b::^b
+
+; Zoom in
+#=::^=
+
+; Zoom out
+#-::^-

--- a/src/app_detector.ts
+++ b/src/app_detector.ts
@@ -1,4 +1,4 @@
-export type SupportedAppKey = 'vscode' | 'vscode-insiders' | 'cursor' | 'windsurf'
+export type SupportedAppKey = 'vscode' | 'vscode-insiders' | 'cursor' | 'windsurf' | 'antigravity'
 
 export function getAppKey(appName: string): SupportedAppKey | undefined {
 	if (appName === 'Visual Studio Code') {
@@ -12,5 +12,8 @@ export function getAppKey(appName: string): SupportedAppKey | undefined {
 	}
 	if (appName.startsWith('Windsurf')) {
 		return 'windsurf'
+	}
+	if (appName.startsWith('Antigravity')) {
+		return 'antigravity'
 	}
 }

--- a/src/app_detector.unit.ts
+++ b/src/app_detector.unit.ts
@@ -9,4 +9,12 @@ suite('getAppKey', () => {
 	test('should return vscode-insiders for Visual Studio Code - Insiders', () => {
 		assert.strictEqual(getAppKey('Visual Studio Code - Insiders'), 'vscode-insiders')
 	})
+
+	test('should return antigravity for Antigravity', () => {
+		assert.strictEqual(getAppKey('Antigravity'), 'antigravity')
+	})
+
+	test('should return antigravity for Antigravity Next', () => {
+		assert.strictEqual(getAppKey('Antigravity Next'), 'antigravity')
+	})
 })


### PR DESCRIPTION
## Summary

- Added `'antigravity'` to the `SupportedAppKey` union type in `app_detector.ts`
- Added `startsWith('Antigravity')` detection branch for Google's new AI IDE
- Created `default_ahk/antigravity.ahk` with standard VS Code shortcut mappings targeting `Antigravity.exe`
- Added 2 unit tests covering Antigravity app name detection

## Test plan

- [x] All 8 unit tests pass (`npm test`)
- [ ] On Windows with Antigravity installed: verify Win+C/V/S/F shortcuts work inside the editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)