### PR TITLE
ci: pin shared workflows to @v1

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   code:
-    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@v1
     with:
       os: '["ubuntu-latest"]'
       node-version: '[24]'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     - created
 jobs:
   code:
-    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@main
+    uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@v1
     with:
       os: '["ubuntu-latest"]'
       node-version: '[24]'


### PR DESCRIPTION
Pins the shared `cyberuni/.github` workflows from `@main` to the new `@v1` tag.

**Why:** every repo in the org tracked the tip of the shared branch, so any change to a shared workflow landed everywhere at once with no opt-in. `v1` is cut at the current known-good `main`, so this is a no-op today — it just stops the repo from riding the tip.

From here, compatible changes move the `v1` tag; breaking ones cut `v2` and repos upgrade on their own schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)