### PR TITLE
fix: stop biome formatting the generated skills-lock.json

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"includes": ["**", "!**/default-keybindings*.jsonc"]
+		"includes": ["**", "!**/default-keybindings*.jsonc", "!skills-lock.json"]
 	},
 	"linter": {
 		"rules": {


### PR DESCRIPTION
Step 1 of #48 — the blocker that has to land before anything else in that issue takes effect.

## What was broken

`release.yml` declares `release: needs: code`. `code` has failed on every run since **2026-05-19**, so `release` has been **skipped**, not failed — the extension has not published in nearly three months, and nothing was red on `main`.

The cause is not code:

```
skills-lock.json format ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  × Formatter would have printed the following content:
     25 │ + "skillPath": "skills/validate-skill/SKILL.md",
     26 │ + "computedHash": "dac87a91e4..."
Checked 20 files in 11ms. No fixes applied.
Found 1 error.
```

Biome's formatter disagrees with the layout the skills lockfile generator writes. `check` runs in `pretest` → `test` → `verify`, so one formatting opinion about a generated file has blocked every release.

## The fix

Ignore `skills-lock.json` in `biome.json`. It is generated output — reformatting it would be undone the next time the generator runs, which is why the file itself is not the thing to change.

## Verified locally, not assumed

```
BEFORE:  pnpm check → "Some errors were emitted while running checks."   exit 1
AFTER:   pnpm check → "Checked 19 files in 8ms. No fixes applied."       exit 0
```

The 20 → 19 file count is the confirmation that the exclusion matched exactly one file and nothing else. `pnpm run compile` also exits 0.

## What this does not fix

Only the pipeline. The remaining items in #48 — removing `CI_GITHUB_TOKEN`, dropping `@semantic-release/git`, applying the baseline ruleset, and settling on one dependency updater — are unchanged and still ordered behind this.

**A green run here is still not proof of a release.** Once this merges, `release` will actually execute for the first time since May; the marketplace version advancing is the real confirmation, and it is worth watching that run rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)