### PR TITLE
ci: publish to the Marketplace with federated identity, not VSCE_PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       contents: write # to be able to publish a GitHub release
       issues: write # to be able to comment on released issues
       pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to mint the OIDC token azure/login exchanges for a credential
     steps:
     - name: "Start X Virtual Frame Buffer"
       run: "echo \"DISPLAY=:99.0\" >> $GITHUB_ENV && Xvfb :99 -screen 0 1920x1080x24 > /dev/null 2>&1 &"
@@ -27,6 +28,18 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.CI_GITHUB_TOKEN }}
+    # Federated identity, no stored credential. The trust is the federated credential
+    # on the Entra app registration, bound to this repo and branch — the client and
+    # tenant IDs are identifiers, not secrets, which is why they are `vars`.
+    #
+    # `allow-no-subscriptions` because publishing to the Marketplace is not tied to an
+    # Azure subscription; a tenant-level login is all vsce needs.
+    - uses: azure/login@v2
+      with:
+        client-id: ${{ vars.AZURE_CLIENT_ID }}
+        tenant-id: ${{ vars.AZURE_TENANT_ID }}
+        allow-no-subscriptions: true
+
     - uses: pnpm/action-setup@v4
     - name: Install Node.js
       uses: actions/setup-node@v4
@@ -40,7 +53,9 @@ jobs:
       run: pnpx semantic-release
       env:
         GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
-        VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        # Replaces VSCE_PAT. semantic-release-vsce errors if BOTH are set, so the
+        # VSCE_PAT line must stay deleted even though the org secret still exists.
+        VSCE_AZURE_CREDENTIAL: 'true'
         OVSX_PAT: ${{ secrets.OVSX_TOKEN }}
   # docgen:
   #     uses: unional/.github/.github/workflows/pnpm-docs.yml@main


### PR DESCRIPTION
**Draft — cannot pass until the Entra identity exists and is a member of the `unional` publisher.** Merging before then swaps a dead PAT for a dead login.

Refs #48. Follows #49, which fixed the first of two reasons this repo has not published since May.

## Why

`VSCE_PAT` expired (last set 2025-07-13; Azure DevOps PATs cap at one year), and the release now fails at `verifyConditions`:

```
[semantic-release] › ✘  EINVALIDVSCEPAT Invalid vsce personal access token or azure credential.
Error: {"message":"Access Denied: The Personal Access Token used has expired."}
```

Rotating it would work — until **2026-12-01, when Azure DevOps retires global PATs entirely**. Any PAT issued today is a stopgap with under four months of life, so this goes straight to the replacement.

## What changes

- `id-token: write` on the release job, so the runner can mint the OIDC token.
- `azure/login@v2` with `allow-no-subscriptions: true` — Marketplace publishing is not tied to an Azure subscription, so a tenant-level login is all `vsce` needs.
- `VSCE_PAT` → `VSCE_AZURE_CREDENTIAL: 'true'`, which makes `semantic-release-vsce` invoke `vsce --azure-credential`.

**No stored credential.** Trust comes from a federated credential on the Entra app registration, bound to this repo and branch. `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` are identifiers, not secrets, so they are `vars` — putting them in `secrets` would imply a sensitivity they do not have.

`VSCE_PAT` must stay deleted from the env: `semantic-release-vsce` errors if both it and `VSCE_AZURE_CREDENTIAL` are set, so leaving the old line as a fallback would break rather than protect.

## Deliberately not included

`CI_GITHUB_TOKEN` is untouched. Removing it is #48 step 2 and requires dropping `@semantic-release/git` first, which is an independent change with its own failure mode. Bundling them would make a bisect meaningless if the release breaks again.

## Prerequisites, in order

1. Entra app registration; record **Application (client) ID** and **Directory (tenant) ID**.
2. Federated credential on that app: *GitHub Actions*, org `cyberuni`, repo `vscode-mac-shortcut-mapper`, entity **Branch**, branch `main` → subject `repo:cyberuni/vscode-mac-shortcut-mapper:ref:refs/heads/main`.
3. Add the identity as a member of the **`unional`** Marketplace publisher with the **Contributor** role. *(All three extensions publish under `unional`, so this authorizes them all — `neo-ltex` and `typings` are unaffected.)*
4. Set repo or org **variables** `AZURE_CLIENT_ID` and `AZURE_TENANT_ID`.

## Known unknown

Microsoft documents this path with a **user-assigned managed identity**, added to the publisher by resource ID — which needs an Azure subscription. This PR takes the app-registration route, which needs none, on the expectation that the publisher Members UI accepts a service principal. **If it does not, that is where this stops**, and the fallback is a rotated PAT plus a dated follow-up before 2026-12-01.

## Verifying

The release runs on push to `main`, so this only proves itself after merge. The check is the **marketplace version advancing** — the run going green proves the login worked, not that anything published. This repo has now produced three separate green-but-published-nothing outcomes; do not accept a fourth.

## Follow-ups

- `unional/vscode-sort-package-json` needs the same change and its own federated credential (`repo:unional/vscode-sort-package-json:ref:refs/heads/main`). It is user-owned, so it needs its own repo variables.
- `.releaserc.json` lists branches `main`, `next`, `beta`. Only `main` gets a federated credential here; `next`/`beta` releases would each need one.
- The `release: types: [created]` trigger runs with a **tag** ref, which no branch-bound credential matches. Since semantic-release creates that release itself, the trigger looks vestigial and risks a second publish attempt — worth removing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)