### PR TITLE
fix: install @vscode/vsce, not the deprecated vsce package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,10 @@ jobs:
         node-version: 24
         cache: pnpm
     - run: pnpm install
-    - run: pnpm add -g vsce ovsx
+    # `@vscode/vsce`, not `vsce`. The old package is deprecated ("vsce has been renamed
+    # to @vscode/vsce") and frozen at 2.15.0, which predates `--azure-credential` — so
+    # semantic-release-vsce fails with `unknown option '--azure-credential'`.
+    - run: pnpm add -g @vscode/vsce ovsx
     - name: Publish
       # if: success() && startsWith(github.ref, 'refs/tags/')
       run: pnpx semantic-release


### PR DESCRIPTION
Refs #48. Third and hopefully last fault in the chain that has kept this repo from publishing since May.

## Where we got to

With #53 merged and the OIDC subject fixed, `azure/login` now **succeeds** — federated identity works, and the `unional` publisher accepted the app registration. Publishing then failed on this:

```
ExecaError: Command failed with exit code 1: vsce verify-pat --azure-credential
error: unknown option '--azure-credential'
```

## Cause

The workflow ran `pnpm add -g vsce ovsx`. npm says of that package:

```
vsce               version = 2.15.0
                   deprecated = 'vsce has been renamed to @vscode/vsce.
                                 Install using @vscode/vsce instead.'
```

`vsce` is frozen at **2.15.0**, published long before `--azure-credential` existed. `@vscode/vsce` is at **3.9.2** and supports it. So `semantic-release-vsce` did the right thing and the binary on PATH was seven years of releases behind.

This was invisible while the repo used `VSCE_PAT`, because 2.15.0 handles PATs perfectly well. Moving to federated identity is what exposed it.

## Fix

`pnpm add -g @vscode/vsce ovsx`.

## Also done, outside this PR

Created the missing **`semantic-release`** label. `@semantic-release/github` opens an issue when a release fails, tagged with that label — and GitHub rejects an issue referencing a label that does not exist:

```
Validation Failed: {"value":"semantic-release","resource":"Label","field":"name","code":"invalid"}
```

So every failed release since May tried to report itself and was rejected. **That is why three months of silent failure went unnoticed.** Fixing the label restores the alarm, independent of anything else here.

## Verifying

The check is the **marketplace version advancing past 1.2.1**, not the run going green. This repo has produced four green-or-partially-green runs tonight that published nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)