### PR TITLE
ci: add a one-off workflow to print the identity's Azure DevOps profile ID

### DIFF
--- a/.github/workflows/ado-profile.yml
+++ b/.github/workflows/ado-profile.yml
@@ -1,0 +1,41 @@
+# One-off helper: prints the Azure DevOps profile ID of the publishing identity.
+#
+# A managed identity has NO Azure DevOps profile until it authenticates to Azure DevOps
+# at least once. The Marketplace runs on Azure DevOps and its publisher Members picker
+# only recognises ADO profile IDs — a client ID, a service principal object ID and a
+# managed identity resource ID are all rejected ("TF14045: The identity could not be
+# found" / "Not a valid User Id").
+#
+# The call below both CREATES the profile and returns its id. Paste that id into
+# https://marketplace.visualstudio.com/manage/publishers/unional -> Members, as
+# Contributor. Run this again for any new publishing identity.
+name: ado-profile
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  profile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Create and print the Azure DevOps profile
+        run: |
+          # 499b84ac-1321-427f-aa17-267ca6975798 is Azure DevOps's well-known app ID.
+          az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me \
+            --resource 499b84ac-1321-427f-aa17-267ca6975798 > profile.json
+          cat profile.json
+          ID=$(python3 -c "import json;print(json.load(open('profile.json'))['id'])")
+          echo "### Azure DevOps profile ID" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "$ID" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "Paste this into the publisher's Members tab as Contributor." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Refs #48. Unblocks the last step of the federated-identity migration.

## The problem

The publisher Members picker rejected every identifier we had:

| pasted | result |
|---|---|
| app registration client ID | `TF14045: The identity could not be found` |
| service principal object ID | `TF14045: The identity could not be found` |
| managed identity **resource ID** | `Not a valid User Id` |

And the release fails at `Publish` with:

```
{"message":"The requested operation is not allowed.","typeKey":"InvalidAccessException"}
```

## The cause

**A managed identity has no Azure DevOps profile until it authenticates to Azure DevOps at least once.** The Marketplace runs on Azure DevOps internally and its Members picker only recognises **ADO profile IDs** — not client IDs, not object IDs, not resource IDs. There was simply nothing in the directory for it to find.

## The fix

One API call, made **as the identity**, which both creates the profile and returns the ID the picker accepts:

```bash
az rest -u https://app.vssps.visualstudio.com/_apis/profile/profiles/me \
  --resource 499b84ac-1321-427f-aa17-267ca6975798
```

`499b84ac-1321-427f-aa17-267ca6975798` is Azure DevOps's well-known app ID in Entra.

It cannot be run from Cloud Shell, because that authenticates as **you**, not as the identity. The federated credential in this repo is the only thing that can act as it — hence a workflow.

`workflow_dispatch` requires the file on the default branch, which is why this is a PR rather than something runnable from a branch.

## After merging

1. Run **Actions → ado-profile → Run workflow**.
2. The profile ID is printed in the job summary.
3. Paste it into [the publisher's Members tab](https://marketplace.visualstudio.com/manage/publishers/unional) with role **Contributor**.
4. Re-run the release.

## Keeping it

Worth keeping rather than reverting: `vscode-sort-package-json` needs the same treatment after it moves to cyberuni, and any future publishing identity will hit this exact wall. The workflow is `workflow_dispatch`-only, so it costs nothing until someone needs it — and the comment block records why the obvious IDs don't work, which is the part that took four attempts to establish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)