### PR TITLE
ci: allow the release to be triggered manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
   release:
     types:
     - created
+  # Re-running a PREVIOUS release run does not work: it checks out that run's commit, and
+  # semantic-release refuses with "The local branch main is behind the remote one,
+  # therefore a new version won't be published." A fresh run on current main is required,
+  # so allow triggering one without inventing a dummy commit.
+  workflow_dispatch:
 jobs:
   code:
     uses: cyberuni/.github/.github/workflows/pnpm-verify.yml@v1


### PR DESCRIPTION
Refs #48.

## Why

The last release run went **fully green and published nothing**:

```
ℹ  The local branch main is behind the remote one, therefore a new version won't be published.
```

That was a re-run of an earlier run, which checks out *that run's* commit. `main` had since moved on, and semantic-release correctly declines to release from a stale branch. Nothing was broken — the recovery method was wrong.

Without `workflow_dispatch`, the only way to retry a release is to push another commit to `main` purely to trigger one. This adds the missing trigger, and the comment records why re-running is not a substitute.

## Note

Merging this is itself a push to `main`, so it triggers a fresh release run on current `main` — which is the run that should finally publish, now that the identity is a Contributor on the `unional` publisher.

## State going in

- Marketplace: **1.2.1**, last updated 18 May 2026
- Latest GitHub release: **v1.2.1**
- Issue #55 (auto-filed release failure): **open**

All three should change if this publishes. If the run goes green and they do not, it did not publish — that distinction has been the recurring lesson on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)